### PR TITLE
add: notes in acodion

### DIFF
--- a/app/views/diaries/show.html.erb
+++ b/app/views/diaries/show.html.erb
@@ -35,6 +35,23 @@
             Today I Learned
           </h2>
           <p class="text-lg leading-relaxed text-base-content"><%= @diary.til_text %></p>
+          
+          <% if @diary&.notes.present? %>
+            <div class="mt-6">
+              <div class="collapse collapse-arrow bg-base-200 border border-base-300">
+                <input type="checkbox" />
+                <div class="collapse-title text-xl font-bold text-secondary flex items-center gap-2">
+                  <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"></path>
+                  </svg>
+                  学習メモ
+                </div>
+                <div class="collapse-content">
+                  <div class="whitespace-pre-line text-base leading-relaxed text-base-content pt-2"><%= @diary.notes %></div>
+                </div>
+              </div>
+            </div>
+          <% end %>
         <% elsif @diary&.notes.present? %>
           <h2 class="flex items-center gap-2 text-2xl font-bold text-secondary mb-4">
             <svg class="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">


### PR DESCRIPTION
# feat: 日記詳細画面での学習メモ表示改善

## 概要
日記詳細画面において、学習メモ（notes）の表示方法を改善しました。TILが選択されている場合でも、学習メモをアコーディオン形式で確認できるようになりました。

## 変更内容

### 表示ロジックの改善
- **TILあり + 学習メモあり**: TILを通常表示し、その下に学習メモをアコーディオン形式で表示
- **TILなし + 学習メモあり**: 学習メモを通常表示（従来通り）
- **学習メモなし**: 「メモなし」メッセージを表示

### 実装詳細
- `app/views/diaries/show.html.erb` にアコーディオン機能を追加
- DaisyUIの `collapse` コンポーネントを使用
- TIL選択後も元の学習メモを参照可能

## 利点
1. **情報の保持**: TIL選択後も元の学習メモを確認できる
2. **UI改善**: アコーディオンにより画面の情報密度を適切に管理
3. **ユーザビリティ向上**: 学習過程を振り返りやすくなる

## 対象ファイル
- `app/views/diaries/show.html.erb`

## テスト項目
- [x] TILが選択されている日記で学習メモがアコーディオン表示される
- [x] TILが未選択の日記で学習メモが通常表示される
- [x] 学習メモがない日記で適切なメッセージが表示される
- [x] アコーディオンの開閉が正常に動作する
