### PR TITLE
fix: 日記の並び順を日付順かつ作成時間順に修正

### DIFF
--- a/app/controllers/diaries_controller.rb
+++ b/app/controllers/diaries_controller.rb
@@ -15,7 +15,7 @@ class DiariesController < ApplicationController
     @diaries = filter_diaries_by_month(
       current_user.diaries.includes(:diary_answers, :til_candidates),
       @selected_month
-    ).order(date: :desc)
+    ).order(date: :desc, created_at: :desc)
     @available_months = available_months
   end
 
@@ -35,7 +35,7 @@ class DiariesController < ApplicationController
   def public_index
     @diaries = Diary.public_diaries
                     .includes(user: [], diary_answers: [:answer])
-                    .order(date: :desc)
+                    .order(date: :desc, created_at: :desc)
                     .limit(20)
   end
 


### PR DESCRIPTION
- diary/indexとpublic_indexの両方で、日記を日付の降順（新しい順）で表示
- 同じ日付内では作成時間の降順（新しい順）で表示するように変更
- これにより、同日の複数の日記がある場合、最新の日記が上部に表示される

🤖 Generated with [Claude Code](https://claude.ai/code)