### PR TITLE
fix: DaisyUIタブの背景色切り替え問題を修正

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -185,31 +185,6 @@ label:has(input[type="radio"]:checked) {
     inset -6px -6px 12px rgba(140, 220, 150, 0.8);
 }
 
-/* DaisyUI Tab customization for neumorphism */
-.tabs-boxed {
-  background: oklch(91.8% 0.018 123.72); /* lemonade base-200 */
-  border-radius: 24px;
-  box-shadow: 
-    20px 20px 40px rgba(105, 169, 106, 0.3),
-    -20px -20px 40px rgba(255, 254, 213, 1);
-  padding: 0.5rem;
-}
-
-.tabs-boxed .tab {
-  /* iOS Safari fixes for tab overlapping */
-  -webkit-appearance: none;
-  appearance: none;
-}
-
-.tabs-boxed .tab:checked {
-  background: oklch(58.92% 0.199 134.6); /* lemonade primary */
-  color: oklch(11.784% 0.039 134.6); /* lemonade primary-content */
-  box-shadow: 
-    inset 6px 6px 12px rgba(58, 120, 106, 0.4),
-    inset -6px -6px 12px rgba(140, 220, 150, 0.8);
-}
-
-
 /* Simple Calendar Navigation Styling */
 .simple-calendar {
   border: none;
@@ -427,12 +402,6 @@ label:has(input[type="radio"]:checked) {
   .fixed.bottom-0 {
     padding-bottom: env(safe-area-inset-bottom);
   }
-  
-  /* iOS Safari specific fixes for tabs */
-  .tabs-boxed {
-    -webkit-overflow-scrolling: touch;
-  }
-  
 }
 
 /* iOS Safari viewport height fix utility */

--- a/app/views/diaries/index.html.erb
+++ b/app/views/diaries/index.html.erb
@@ -16,31 +16,25 @@
 
   <!-- DaisyUI Tab Navigation -->
   <div class="flex justify-start items-center mb-4 animate-[slideInLeft_0.5s_ease-out_0.2s_both]">
-    <div class="tabs tabs-boxed tabs-sm flex flex-nowrap overflow-x-auto" role="tablist" aria-label="日記表示切り替え">
+    <div class="tabs tabs-box tabs-sm" aria-label="日記表示切り替え">
       <input 
         type="radio" 
         name="diary_view_tabs" 
-        class="tab whitespace-nowrap flex-none min-w-fit relative z-10 rounded-2xl font-medium transition-all duration-200 p-2 px-4" 
+        class="tab" 
         aria-label="📅 カレンダー"
         id="calendar-tab"
-        checked="checked"
+        checked
         data-action="change->diary-view#showCalendarView"
-        role="tab"
-        aria-selected="true"
-        aria-controls="calendar-view"
       />
       
       <input 
         type="radio" 
         name="diary_view_tabs" 
-        class="tab whitespace-nowrap flex-none min-w-fit relative z-10 rounded-2xl font-medium transition-all duration-200 p-2 px-4" 
+        class="tab" 
         aria-label="📋 リスト"
         id="list-tab"
         data-diary-view-target="listTab"
         data-action="change->diary-view#showListView"
-        role="tab"
-        aria-selected="false"
-        aria-controls="list-view"
       />
     </div>
 


### PR DESCRIPTION
- 余分なARIA属性（role, aria-selected, aria-controls）を削除
- カスタムCSSによるタブスタイルのオーバーライドを削除
- DaisyUIのデフォルト動作に任せることで正常に動作するように修正

タブをクリックした際に背景色が正しく切り替わらない問題を解決

🤖 Generated with [Claude Code](https://claude.ai/code)