### PR TITLE
Fix/OpenAI model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,5 @@ work_log/
 pr.md
 CLAUDE.md
 /public/uploads/
+
+.serena

--- a/app/services/openai_service/base.rb
+++ b/app/services/openai_service/base.rb
@@ -3,6 +3,7 @@ class OpenaiService::Base
   DEFAULT_MAX_TOKENS = 200
   INPUT_MAX_LENGTH = 1000
   DEFAULT_TIMEOUT = 15
+  EFFORT_LEVEL = "minimal".freeze
 
   def initialize
     @client = OpenAI::Client.new(
@@ -45,13 +46,13 @@ class OpenaiService::Base
   def til_generation_parameters(notes)
     sanitized_notes = sanitize_user_input(notes)
     {
-      model: "gpt-4.1-nano-2025-04-14",
+      model: "gpt-5-nano",
       messages: [
         { role: "system", content: system_prompt },
         { role: "user", content: "以下の今日のメモに基づいて文章を生成してください:\n#{sanitized_notes}" }
       ],
       temperature: ai_temperature,
-      max_tokens: ai_max_tokens
+      reasoning_effort: effort_level
     }
   end
 
@@ -88,6 +89,10 @@ class OpenaiService::Base
 
   def ai_max_tokens
     DEFAULT_MAX_TOKENS # デフォルト値、サブクラスでオーバーライド可能
+  end
+
+  def effort_level
+    EFFORT_LEVEL # デフォルト値、サブクラスでオーバーライド可能
   end
 
   def openai_timeout


### PR DESCRIPTION
# プルリクエスト: OpenAI API モデル更新対応

## 概要
OpenAI APIのモデルをgpt-4.1-nano-2025-04-14からgpt-5-nanoに更新し、新しいAPIパラメータ`reasoning_effort`に対応しました。

## 変更内容

### コミット履歴
- `c2bbe93` chore: Add .serena to .gitignore
- `baa064c` fix: Upgrade OpenAI model to gpt-5-nano with reasoning_effort

### 主な変更点

#### 1. .gitignoreの更新
- `.serena`ディレクトリを除外対象に追加
- 開発環境の設定ファイルの誤コミットを防止

#### 2. OpenAI Service Base クラスの更新 (`app/services/openai_service/base.rb`)

**モデル更新:**
- `gpt-4.1-nano-2025-04-14` → `gpt-5-nano`
- 最新のOpenAI APIモデルに対応

**APIパラメータ変更:**
- `max_tokens` → `reasoning_effort`
- 新しいパラメータ体系に準拠

**新規追加項目:**
- `EFFORT_LEVEL = "minimal".freeze` 定数追加
- `effort_level` メソッド追加（サブクラスでオーバーライド可能）

## 技術的検証

## 影響範囲
- TIL生成機能（`OpenaiService::TilGenerator`）
- API呼び出し処理全般
- 外部依存関係: OpenAI gem（バージョン確認必要）
